### PR TITLE
Add support for primitive classes

### DIFF
--- a/vm/src/alloc/heap.rs
+++ b/vm/src/alloc/heap.rs
@@ -88,6 +88,7 @@ impl Heap {
     /// Returns the java.lang.Class object for the class represented by
     /// `class_name`.
     pub(crate) fn get_class_obj(&self, class_name: &str) -> ObjRef {
+        println!("getting class_obj: {class_name}");
         // SAFETY: Since we manage the pointer ourselves, we know it is valid
         // as long as the pointer wasn't invalidated elsewhere.
         unsafe { ObjRef::from_raw(*self.classes.get(class_name).unwrap()) }

--- a/vm/src/lli/class_manager.rs
+++ b/vm/src/lli/class_manager.rs
@@ -42,6 +42,31 @@ impl ClassManager {
         }
     }
 
+    pub(crate) fn init_prim_classes(&mut self, met_area: &mut MethodArea) -> Vec<&'static Class> {
+        use sumatra_parser::desc_types::Primitive;
+
+        let prims = [
+            Primitive::Boolean,
+            Primitive::Byte,
+            Primitive::Char,
+            Primitive::Double,
+            Primitive::Float,
+            Primitive::Int,
+            Primitive::Long,
+            Primitive::Short,
+        ];
+
+        prims
+            .into_iter()
+            .map(|prim| {
+                let (class, _) = self
+                    .store_class(Class::primitive_class(prim), met_area)
+                    .unwrap();
+                class
+            })
+            .collect::<Vec<&'static Class>>()
+    }
+
     pub(crate) fn request(&mut self, name: &str, met_area: &mut MethodArea) -> Result<Response> {
         let response = if name.starts_with("[") {
             self.resolve_array_class(name, met_area)
@@ -141,6 +166,10 @@ impl ClassManager {
     ) -> Result<(&'static Class, usize)> {
         let name = class.get_name();
         let index = met_area.push(class)?;
+
+        //TODO these next two lines need to be fixed. If
+        //the thread is interupted between the lines, and id
+        //is modified the wrong number will be stored.
         let id = self.count.load(Ordering::SeqCst);
         self.count.store(id + 1, Ordering::SeqCst);
         self.by_id.insert(id, index);

--- a/vm/src/native/lib_java/lang/java_class.rs
+++ b/vm/src/native/lib_java/lang/java_class.rs
@@ -150,7 +150,6 @@ fn jvm_get_primitive_class(
         panic!("bytes was not a RefType::Array as expected in jvm_get_primitive_class");
     };
     let bytes = bytes.get_all();
-
     let primitive_name = bytes
         .iter()
         .enumerate()
@@ -162,20 +161,7 @@ fn jvm_get_primitive_class(
         })
         .collect::<String>();
 
-    //TODO fix this. int.class does NOT return a java/lang.Integer.class!
-    let class_name = match primitive_name.as_bytes() {
-        b"boolean" => "java/lang/Boolean",
-        b"byte" => "java/lang/Byte",
-        b"char" => "java/lang/Char",
-        b"double" => "java/lang/Double",
-        b"float" => "java/lang/Float",
-        b"int" => "java/lang/Integer",
-        b"long" => "java/lang/Long",
-        b"short" => "java/lang/Short",
-        b"void" => "java/lang/Void",
-        primitive => panic!("Invalid primitive type: {primitive:?} in jvm_get_primitive_class."),
-    };
-    let string_obj = vm.heap().get_class_obj(class_name);
+    let string_obj = vm.heap().get_class_obj(&primitive_name);
     Ok(Some(Value::new_object(string_obj)))
 }
 


### PR DESCRIPTION
Added support for primitive class (int.class, boolean.class, ect). This required changing the definition of a class is class.rs and add bootstrapping logic to load the primitive classes when bootstrapping the core classes. 